### PR TITLE
Force consistent light mode by removing system color-scheme overrides

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,69 +1,35 @@
 @import "tailwindcss";
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color-scheme: light;
+  color: #1e293b;
+  background-color: #f8fafc;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html,
+body,
+#root {
+  width: 100%;
+  min-height: 100%;
 }
 
 body {
-  height: 100%;
-  width: 100%;
   margin: 0;
   padding: 0;
   overflow-x: hidden;
+  background-color: #f8fafc;
+  color: #1e293b;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+/* Keep anchor defaults neutral so Tailwind utility classes remain the primary source of styling. */
+a {
+  color: inherit;
+  text-decoration: inherit;
 }


### PR DESCRIPTION
### Motivation
- Prevent visual inconsistencies when the OS/browser switches to dark mode by locking the app to a light-only global theme and avoiding global CSS overrides that conflict with component-level styling.

### Description
- Replaced the Vite/default global styles in `src/index.css` to set `color-scheme: light`, align root/body text and background to the app light palette, remove the `prefers-color-scheme` media query and global `button` overrides, and keep anchor defaults neutral so Tailwind utility classes control component appearance.

### Testing
- Ran `npm run build`, started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, and captured a Playwright screenshot of the home page to validate the light-only rendering, and all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f8bda50c08326994da1d39be2f190)