### PR TITLE
Refactor UI copy and global styles; update AHI analysis messaging

### DIFF
--- a/src/components/EDFUpload.tsx
+++ b/src/components/EDFUpload.tsx
@@ -1074,7 +1074,7 @@ const handleAHIAnalysis = useCallback(async () => {
   const progressSteps = [
     "Initializing Python analysis engine...",
     "Loading full-resolution flow and SpO2 data...",
-    "Applying AASM clinical criteria...",
+    "Applying event scoring criteria...",
     "Detecting apnea events (≥90% flow reduction)...",
     "Detecting hypopnea events (30-90% flow reduction)...",
     "Analyzing oxygen desaturation patterns...",

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -229,7 +229,7 @@ const ModeSelector: React.FC<ModeSelectorProps> = ({
                 </div>
                 <div className="flex items-center space-x-2">
                   <div className="w-2 h-2 bg-red-500 rounded-full"></div>
-                  <span className="text-xs text-red-600 font-medium">Medical Analysis</span>
+                  <span className="text-xs text-red-600 font-medium">AHI Analysis</span>
                 </div>
               </div>
             </div>
@@ -238,7 +238,7 @@ const ModeSelector: React.FC<ModeSelectorProps> = ({
                 <div className="flex items-start space-x-3">
                   <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5" />
                   <div>
-                    <p className="text-sm text-red-700 font-medium mb-1">Clinical Requirements</p>
+                    <p className="text-sm text-red-700 font-medium mb-1">Analysis Requirements</p>
                     <p className="text-sm text-red-600">
                       Requires both Flow (airflow) and SpO2 (oxygen saturation) channels for accurate analysis.
                     </p>
@@ -390,7 +390,7 @@ const ModeSelector: React.FC<ModeSelectorProps> = ({
                             {ahiResults.ahi_analysis.severity}
                           </div>
                           <div className="text-xs font-medium text-slate-600 uppercase tracking-wide">Severity Level</div>
-                          <div className="text-xs text-slate-500">Clinical Assessment</div>
+                          <div className="text-xs text-slate-500">Severity Band</div>
                         </div>
                       </div>
                       

--- a/src/index.css
+++ b/src/index.css
@@ -1,69 +1,35 @@
 @import "tailwindcss";
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color-scheme: light;
+  color: #1e293b;
+  background-color: #f8fafc;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html,
+body,
+#root {
+  width: 100%;
+  min-height: 100%;
 }
 
 body {
-  height: 100%;
-  width: 100%;
   margin: 0;
   padding: 0;
   overflow-x: hidden;
+  background-color: #f8fafc;
+  color: #1e293b;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+/* Keep anchor defaults neutral so Tailwind utility classes remain the primary source of styling. */
+a {
+  color: inherit;
+  text-decoration: inherit;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,7 +8,6 @@ import {
   X,
   Brain,
   Heart,
-  Stethoscope,
   Shield
 } from "lucide-react";
 import EDFUpload from "../components/EDFUpload";
@@ -62,16 +61,16 @@ export default function Home() {
             </a>*/}
           </nav>
 
-          {/* Right side - Medical badges */}
+          {/* Right side - Product badges */}
           <div className="ml-auto flex items-center space-x-4">
             <div className="hidden lg:flex items-center space-x-3">
               <div className="flex items-center space-x-1 px-3 py-1 bg-emerald-50 text-emerald-700 rounded-full text-xs font-medium">
                 <Shield className="h-3 w-3" />
-                <span>HIPAA Compliant</span>
+                <span>Secure Upload</span>
               </div>
               <div className="flex items-center space-x-1 px-3 py-1 bg-blue-50 text-blue-700 rounded-full text-xs font-medium">
-                <Stethoscope className="h-3 w-3" />
-                <span>Medical Grade</span>
+                <Activity className="h-3 w-3" />
+                <span>Interactive Analysis</span>
               </div>
             </div>
           </div>
@@ -130,23 +129,23 @@ export default function Home() {
               <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent"> Analysis Platform</span>
             </h1>
             <p className="text-xl text-slate-600 mb-8 leading-relaxed">
-              Upload EDF recordings and explore sleep study data with professional-grade visualization tools, 
+              Upload EDF recordings and explore sleep study data with practical visualization tools, 
               AHI analysis, and comprehensive reporting capabilities.
             </p>
             
-            {/* Medical credibility indicators */}
+            {/* Product highlights */}
             <div className="flex flex-wrap justify-center gap-6 mb-8">
               <div className="flex items-center space-x-2 text-slate-600">
                 <div className="w-2 h-2 bg-emerald-500 rounded-full"></div>
-                <span className="text-sm font-medium">FDA Compliant Algorithms</span>
+                <span className="text-sm font-medium">Flexible Channel Selection</span>
               </div>
               <div className="flex items-center space-x-2 text-slate-600">
                 <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-                <span className="text-sm font-medium">Clinical Grade Accuracy</span>
+                <span className="text-sm font-medium">Detailed Signal Visualization</span>
               </div>
               <div className="flex items-center space-x-2 text-slate-600">
                 <div className="w-2 h-2 bg-purple-500 rounded-full"></div>
-                <span className="text-sm font-medium">AASM Standards</span>
+                <span className="text-sm font-medium">AHI Summary Insights</span>
               </div>
             </div>
           </div>
@@ -157,15 +156,15 @@ export default function Home() {
           <EDFUpload />
         </div>
 
-        {/* Footer with medical compliance info */}
+        {/* Footer */}
         <footer className="mt-16 pt-8 border-t border-slate-200">
           <div className="flex flex-col lg:flex-row justify-between items-center space-y-4 lg:space-y-0">
             <div className="flex items-center space-x-6 text-sm text-slate-500">
               <span>© 2025 SomnoViz. All rights reserved.</span>
               <span>•</span>
-              <span>HIPAA Compliant</span>
+              <span>Sleep Data Visualization</span>
               <span>•</span>
-              <span>SOC 2 Type II</span>
+              <span>Web Platform</span>
             </div>
             <div className="flex items-center space-x-4">
               <div className="flex items-center space-x-2 px-3 py-1 bg-slate-50 rounded-full">


### PR DESCRIPTION
### Motivation
- Reduce clinical/compliance phrasing in the UI and shift language toward product-focused, non-medical wording.
- Clarify AHI analysis progress messaging to be less clinical and more descriptive of event scoring steps.
- Move the app to a neutral light styling baseline and simplify global styles to avoid opinionated element defaults.

### Description
- Changed the AHI analysis progress text in `src/components/EDFUpload.tsx` from "Applying AASM clinical criteria..." to "Applying event scoring criteria..." and kept the existing progress update flow.
- Adjusted AHI mode UI copy in `src/components/ModeSelector.tsx` including `Medical Analysis` → `AHI Analysis`, `Clinical Requirements` → `Analysis Requirements`, and `Clinical Assessment` → `Severity Band`.
- Updated the main page `src/pages/Home.tsx` by removing a now-unused `Stethoscope` icon import, replacing medical/credibility badges and hero copy with product-focused highlights, and cleaning up footer labels.
- Overhauled global stylesheet `src/index.css` to a light theme baseline, removed many custom element defaults, added `html, body, #root` sizing rules, and neutralized anchor styles to rely on Tailwind utilities.

### Testing
- Ran TypeScript type checking with `yarn tsc` and there were no type errors.
- Executed the app build with `yarn build` which completed successfully.
- Ran the unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f8bda50c08326994da1d39be2f190)